### PR TITLE
Updating Helm Chart meta-data to point to 'spring' branch for Charts

### DIFF
--- a/bluecompute-ce/requirements.yaml
+++ b/bluecompute-ce/requirements.yaml
@@ -1,41 +1,41 @@
 dependencies:
   - name: auth
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: auth.enabled
   - name: catalog
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: catalog.enabled
   - name: catalogelasticsearch
     version: 0.3.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: catalogelasticsearch.enabled
   - name: customer
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: customer.enabled
   - name: customercouchdb
     version: 0.3.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: customercouchdb.enabled
   - name: inventory
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: inventory.enabled
   - name: inventorymysql
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: inventorymysql.enabled
   - name: orders
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: orders.enabled
   - name: ordersmysql
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: ordersmysql.enabled
   - name: web
     version: 0.4.0
-    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts
+    repository: https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts
     condition: web.enabled

--- a/docs/charts/bluecompute-ce/index.yaml
+++ b/docs/charts/bluecompute-ce/index.yaml
@@ -2,43 +2,43 @@ apiVersion: v1
 entries:
   bluecompute-ce:
   - apiVersion: v1
-    created: 2018-06-27T22:03:58.886339976-05:00
+    created: 2018-08-21T12:11:22.783832-05:00
     description: Bluecompute Application Chart
     digest: a75b17096b5ba4a410cfb05479ea7ac08e2d9b1d0f58da55fea6edcad477f606
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.6.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
-    created: 2018-06-27T22:03:58.883657427-05:00
+    created: 2018-08-21T12:11:22.780024-05:00
     description: Bluecompute Application Chart
     digest: ad408ea385ae64492c05745e550a053765e3b51dfbfa4e629e17d220d3c56668
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.5.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.5.tgz
     version: 0.0.5
   - apiVersion: v1
-    created: 2018-06-27T22:03:58.88228843-05:00
+    created: 2018-08-21T12:11:22.778338-05:00
     description: Bluecompute Application Chart
     digest: 8319d3a883008b387459b21d883f110fa2ba73a28a4c2144fea888849a09edab
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.4.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
-    created: 2018-06-27T22:03:58.880941183-05:00
+    created: 2018-08-21T12:11:22.776548-05:00
     description: Bluecompute Application Chart
     digest: f062029c5b56ef738327b30cc11458a8e645204c58bbf2fd05bc614e4c10767f
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.3.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
-    created: 2018-06-27T22:03:58.879718884-05:00
+    created: 2018-08-21T12:11:22.774787-05:00
     description: Bluecompute Application Chart
     digest: f23647fb9829819ca7f27662acdad8891fc345323d49cd5597e643ffe6554afa
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.2.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.2.tgz
     version: 0.0.2
-generated: 2018-06-27T22:03:58.878160309-05:00
+generated: 2018-08-21T12:11:22.772725-05:00

--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -2,222 +2,222 @@ apiVersion: v1
 entries:
   auth:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.849142393-05:00
+    created: 2018-08-21T12:01:54.678028-05:00
     description: BlueCompute Auth Microservice
     digest: 1146305fbddef781b735422fee066a4bd2b8a95cefcd1e29b9842d08ef5e0772
     name: auth
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/auth-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/auth-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.848887109-05:00
+    created: 2018-08-21T12:01:54.677693-05:00
     description: BlueCompute Auth Microservice
     digest: 5a5b5e1335566b98d5f4a1c85718e82b02c73ba9818acd16b662b43991a38006
     name: auth
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/auth-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/auth-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.848668903-05:00
+    created: 2018-08-21T12:01:54.677366-05:00
     description: BlueCompute Auth Microservice
     digest: b90bd11009cd639fbb75a8a0818ce98af7b3054d0fd559a7ed9aaf59dd5eda14
     name: auth
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/auth-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/auth-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.848444229-05:00
+    created: 2018-08-21T12:01:54.677065-05:00
     description: BlueCompute Auth Microservice
     digest: 055b4ab2fad15d874622b02e36ec973c789cd16beffc3baab8e966951fa49123
     name: auth
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/auth-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/auth-0.1.0.tgz
     version: 0.1.0
   bluecompute:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.85143107-05:00
+    created: 2018-08-21T12:01:54.680673-05:00
     description: Bluecompute Application Chart
     digest: aaf31e79a95f0068634bed40874cd049798675ec32b05fa81d8ec830684d4d19
     name: bluecompute
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-0.0.2.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-0.0.2.tgz
     version: 0.0.2
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.867497997-05:00
+    created: 2018-08-21T12:01:54.699269-05:00
     description: Bluecompute Application Chart
     digest: 264ae7bf3a6a39f1402c1c65265014736cad7d533a6eeb80f0dd775ebdae2aee
     name: bluecompute
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute/bluecompute-0.0.1.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute/bluecompute-0.0.1.tgz
     version: 0.0.1
   bluecompute-ce:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.874924208-05:00
+    created: 2018-08-21T12:01:54.708146-05:00
     description: Bluecompute Application Chart
     digest: a75b17096b5ba4a410cfb05479ea7ac08e2d9b1d0f58da55fea6edcad477f606
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.6.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.872963989-05:00
+    created: 2018-08-21T12:01:54.706374-05:00
     description: Bluecompute Application Chart
     digest: ad408ea385ae64492c05745e550a053765e3b51dfbfa4e629e17d220d3c56668
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.5.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.5.tgz
     version: 0.0.5
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.871557299-05:00
+    created: 2018-08-21T12:01:54.703642-05:00
     description: Bluecompute Application Chart
     digest: 8319d3a883008b387459b21d883f110fa2ba73a28a4c2144fea888849a09edab
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.4.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.4.tgz
     version: 0.0.4
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.870120343-05:00
+    created: 2018-08-21T12:01:54.702222-05:00
     description: Bluecompute Application Chart
     digest: f062029c5b56ef738327b30cc11458a8e645204c58bbf2fd05bc614e4c10767f
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.3.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.3.tgz
     version: 0.0.3
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.868798127-05:00
+    created: 2018-08-21T12:01:54.700688-05:00
     description: Bluecompute Application Chart
     digest: f23647fb9829819ca7f27662acdad8891fc345323d49cd5597e643ffe6554afa
     name: bluecompute-ce
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluecompute-ce/bluecompute-ce-0.0.2.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluecompute-ce/bluecompute-ce-0.0.2.tgz
     version: 0.0.2
   bluemixservice:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.851877612-05:00
+    created: 2018-08-21T12:01:54.681242-05:00
     description: Deploy a service in Bluemix and bind to my cluster
     digest: 22b34e23233cbf3583cb4f28d4d1e623d182b2066d8c71208899635711f00911
     icon: http://www-05.ibm.com/il/gtu/img/BluemixLogo_172x203.png
     name: bluemixservice
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluemixservice-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluemixservice-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.851659424-05:00
+    created: 2018-08-21T12:01:54.680944-05:00
     description: Deploy a service in Bluemix and bind to my cluster
     digest: 2d85c24e3119272809ce6abce7bda4d7bce3a1f8615bba26c88de143ac538836
     icon: http://www-05.ibm.com/il/gtu/img/BluemixLogo_172x203.png
     name: bluemixservice
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/bluemixservice-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/bluemixservice-0.2.0.tgz
     version: 0.2.0
   catalog:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.852833344-05:00
+    created: 2018-08-21T12:01:54.683369-05:00
     description: BlueCompute Catalog Microservice
     digest: 03769a0ffbbacae4d7615bfee4d46fa7c6974a80453f8a0c0e9e7e0c4927baec
     name: catalog
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/catalog-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/catalog-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.852616642-05:00
+    created: 2018-08-21T12:01:54.683019-05:00
     description: BlueCompute Catalog Microservice
     digest: dddf4bf63798f7fafd17df8971ec1c9d788c7a36acee6307c01af8db413efada
     name: catalog
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/catalog-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/catalog-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.852428206-05:00
+    created: 2018-08-21T12:01:54.68234-05:00
     description: BlueCompute Catalog Microservice
     digest: edc36cf1605f407ed55078b9e3cd458b533185b2df33af67a9daca879b46faaa
     name: catalog
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/catalog-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/catalog-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.852254107-05:00
+    created: 2018-08-21T12:01:54.681717-05:00
     description: BlueCompute Catalog Microservice
     digest: 5943bf174fa59f6bffafb011c2d35349324907c6c105e0b2f05dea39c59869c1
     name: catalog
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/catalog-0.1.1.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/catalog-0.1.1.tgz
     version: 0.1.1
   catalogelasticsearch:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.853039238-05:00
+    created: 2018-08-21T12:01:54.683619-05:00
     description: ElasticSearch
     digest: ca49960ed0e8129f9b415d53e0a8ac8cf23761b3fb10acef508c6702a400026b
     icon: https://static-www.elastic.co/assets/blt9a26f88bfbd20eb5/icon-elasticsearch-bb.svg
     name: catalogelasticsearch
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/catalogelasticsearch-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/catalogelasticsearch-0.3.0.tgz
     version: 0.3.0
   couchdb:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.853278565-05:00
+    created: 2018-08-21T12:01:54.683887-05:00
     description: CouchDB
     digest: 2cc895678087b66e883b10b1698220ced93311317e6b7f899f1037cbdc166829
     icon: http://couchdb.apache.org/image/couch@2x.png
     name: couchdb
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/couchdb-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/couchdb-0.2.0.tgz
     version: 0.2.0
   customer:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.855234324-05:00
+    created: 2018-08-21T12:01:54.685181-05:00
     description: BlueCompute Customer Microservice
     digest: dfbe786097f59551161a2e10ae90e1a30e86a09b46438d821cf5f087780e0fe5
     name: customer
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/customer-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/customer-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.854953152-05:00
+    created: 2018-08-21T12:01:54.684848-05:00
     description: BlueCompute Customer Microservice
     digest: 3c8c7144dafc9ebe92de7c328a7a3871c504350e0ac79d165afdbb804b0a52c8
     name: customer
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/customer-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/customer-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.85442741-05:00
+    created: 2018-08-21T12:01:54.684566-05:00
     description: BlueCompute Customer Microservice
     digest: edf2fb1c98f4dfbf6d9a6f17742c6e92993a2051ef37bbebca110890a2e8447d
     name: customer
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/customer-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/customer-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.853755003-05:00
+    created: 2018-08-21T12:01:54.684241-05:00
     description: BlueCompute Customer Microservice
     digest: c637de164bd9267688eddd122476551f84712cf14f55f2f0681cb20770b70b5b
     name: customer
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/customer-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/customer-0.1.0.tgz
     version: 0.1.0
   customercouchdb:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.855465323-05:00
+    created: 2018-08-21T12:01:54.685431-05:00
     description: CouchDB
     digest: 1a8aa676af92640a050dedf1d686450f2cabcd7a091c0a7b27a51fce76d79afd
     icon: http://couchdb.apache.org/image/couch@2x.png
     name: customercouchdb
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/customercouchdb-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/customercouchdb-0.3.0.tgz
     version: 0.3.0
   elasticsearch:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.855671932-05:00
+    created: 2018-08-21T12:01:54.685667-05:00
     description: ElasticSearch
     digest: fa85f91ceb19577260af60aba4e5d6a30e8c1378b2d0916bd2d8d146e38b7c53
     icon: https://static-www.elastic.co/assets/blt9a26f88bfbd20eb5/icon-elasticsearch-bb.svg
     name: elasticsearch
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/elasticsearch-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/elasticsearch-0.2.0.tgz
     version: 0.2.0
   grafana-bc:
-  - created: 2018-07-27T16:57:04.856147036-05:00
+  - created: 2018-08-21T12:01:54.686194-05:00
     description: The leading tool for querying and visualizing time series and metrics.
     digest: 41e9b7e0e2532428ac273edf9ef0e0980199cf097dd9b76a9239045752a5c040
     engine: gotpl
@@ -232,67 +232,67 @@ entries:
     sources:
     - https://github.com/grafana/grafana
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/grafana-bc-0.3.1.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/grafana-bc-0.3.1.tgz
     version: 0.3.1
   ibmcase-bluemix-service:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.856602803-05:00
+    created: 2018-08-21T12:01:54.686669-05:00
     description: Deploy a service in Bluemix and bind to my cluster
     digest: 891d48212d4c87809ea2c04ae4b168f0ad72697a621a5748e3fef36ce46420ee
     icon: http://www-05.ibm.com/il/gtu/img/BluemixLogo_172x203.png
     name: ibmcase-bluemix-service
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-bluemix-service-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-bluemix-service-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.856366504-05:00
+    created: 2018-08-21T12:01:54.686432-05:00
     description: Deploy a service in Bluemix and bind to my cluster
     digest: 7165656bb88cf6eb4e4ca945d11680dc7cad672234ba3d54bd9e29aca6124db8
     icon: http://www-05.ibm.com/il/gtu/img/BluemixLogo_172x203.png
     name: ibmcase-bluemix-service
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-bluemix-service-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-bluemix-service-0.1.0.tgz
     version: 0.1.0
   ibmcase-couchdb:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.857085382-05:00
+    created: 2018-08-21T12:01:54.687195-05:00
     description: CouchDB
     digest: 825f516452839bd9f1645dd63a3832ee581cd13ea854521867a5f273c69a4377
     icon: http://couchdb.apache.org/image/couch@2x.png
     name: ibmcase-couchdb
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-couchdb-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-couchdb-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.856840948-05:00
+    created: 2018-08-21T12:01:54.686928-05:00
     description: CouchDB
     digest: 915098959aacf3c0600e7b7270a27ee87912cb98ad11625c1866a9b8b4744535
     icon: http://couchdb.apache.org/image/couch@2x.png
     name: ibmcase-couchdb
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-couchdb-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-couchdb-0.1.0.tgz
     version: 0.1.0
   ibmcase-elasticsearch:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.857502321-05:00
+    created: 2018-08-21T12:01:54.687681-05:00
     description: ElasticSearch
     digest: 7134d432b05c97c2327af7c151145d9c4b3b306b94ac908a8f4609d5fa4be802
     icon: https://static-www.elastic.co/assets/blt9a26f88bfbd20eb5/icon-elasticsearch-bb.svg
     name: ibmcase-elasticsearch
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-elasticsearch-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-elasticsearch-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.857286028-05:00
+    created: 2018-08-21T12:01:54.687427-05:00
     description: ElasticSearch
     digest: 65ffe22f17fcc2583ae4ba2b41727938276b68514f785bd954fd0d574f4c4785
     icon: https://static-www.elastic.co/assets/blt9a26f88bfbd20eb5/icon-elasticsearch-bb.svg
     name: ibmcase-elasticsearch
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-elasticsearch-0.1.1.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-elasticsearch-0.1.1.tgz
     version: 0.1.1
   ibmcase-inventory-mysql:
-  - created: 2018-07-27T16:57:04.858184648-05:00
+  - created: 2018-08-21T12:01:54.688226-05:00
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system.
     digest: 4594adb258e9559da115aa7135436561cbbad1633a76433bfc8f6a89afc097ba
@@ -311,19 +311,19 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/docker-library/mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-inventory-mysql-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-inventory-mysql-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.857801529-05:00
+    created: 2018-08-21T12:01:54.687934-05:00
     description: Resilient MySQL deployment
     digest: 3e2bfd8fb46e9510f11c75518e841eb389fc5d1e6cd213884fc4d654f6465db5
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Octicons-database.svg/200px-Octicons-database.svg.png
     name: ibmcase-inventory-mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-inventory-mysql-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-inventory-mysql-0.2.0.tgz
     version: 0.2.0
   ibmcase-mysql:
-  - created: 2018-07-27T16:57:04.859002211-05:00
+  - created: 2018-08-21T12:01:54.689082-05:00
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system.
     digest: d8310a9ec892201ae6c6c6ea8a7b3171c5239fa2e60c28737164d03912bdcff7
@@ -342,28 +342,28 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/docker-library/mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-mysql-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-mysql-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.858716869-05:00
+    created: 2018-08-21T12:01:54.688803-05:00
     description: Resilient MySQL deployment
     digest: 2797b83e092e8951719637f211e156b566b0e1d56d38de3777e4d54275788e10
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Octicons-database.svg/200px-Octicons-database.svg.png
     name: ibmcase-mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-mysql-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-mysql-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.858474767-05:00
+    created: 2018-08-21T12:01:54.688525-05:00
     description: Resilient MySQL deployment
     digest: 1d86b7df0cf578eca21dc46e0fd056344d1eb41572801097b3ae8dcefac12a4d
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Octicons-database.svg/200px-Octicons-database.svg.png
     name: ibmcase-mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-mysql-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-mysql-0.1.0.tgz
     version: 0.1.0
   ibmcase-orders-mysql:
-  - created: 2018-07-27T16:57:04.859511115-05:00
+  - created: 2018-08-21T12:01:54.689707-05:00
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system.
     digest: 81bc4982cfb819be66b33418fd660581c500e5ca7319ef373992c3f9419eca68
@@ -382,60 +382,60 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/docker-library/mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-orders-mysql-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-orders-mysql-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.859231122-05:00
+    created: 2018-08-21T12:01:54.689416-05:00
     description: Resilient MySQL deployment
     digest: 1e73e4cff77e12b278cc1006c7a796ce2f96deac86f6dabd6cd4ccb44acc945d
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Octicons-database.svg/200px-Octicons-database.svg.png
     name: ibmcase-orders-mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ibmcase-orders-mysql-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ibmcase-orders-mysql-0.2.0.tgz
     version: 0.2.0
   inventory:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.861459511-05:00
+    created: 2018-08-21T12:01:54.692236-05:00
     description: BlueCompute Inventory Microservice
     digest: 036114ef300c892070126fb441bb56b91f90e5284c29e6fb06c585fb2b13411b
     name: inventory
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventory-0.5.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventory-0.5.0.tgz
     version: 0.5.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.86062965-05:00
+    created: 2018-08-21T12:01:54.691211-05:00
     description: BlueCompute Inventory Microservice
     digest: bb37c74c9eee3e08f744c6befbe6142af8e76f61baf318a165c1c0c6adbfa19a
     name: inventory
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventory-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventory-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.860392985-05:00
+    created: 2018-08-21T12:01:54.690862-05:00
     description: BlueCompute Inventory Microservice
     digest: 4b2cb79db25c6cef26251a1b64ba67388518375327a8817ee1f09ec80c1dc58b
     name: inventory
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventory-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventory-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.860183463-05:00
+    created: 2018-08-21T12:01:54.690592-05:00
     description: BlueCompute Inventory Microservice
     digest: ff3cf76e411f12d97a260eb30646c0451aa6ad2e9f4fd7633fee92e33ec0db35
     name: inventory
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventory-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventory-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.859977649-05:00
+    created: 2018-08-21T12:01:54.690309-05:00
     description: BlueCompute Inventory Microservice
     digest: 27099b492c0de3ff363a2eafc79a823a14adf2f4ef1667ae7fad0b2b8287e1bf
     name: inventory
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventory-0.1.1.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventory-0.1.1.tgz
     version: 0.1.1
   inventorymysql:
-  - created: 2018-07-27T16:57:04.861760391-05:00
+  - created: 2018-08-21T12:01:54.692542-05:00
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system.
     digest: bd6774dbb1cbe81a9e69143e997714c68ae1d14d20a179d7043fb7c94b59e7d0
@@ -454,53 +454,53 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/docker-library/mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/inventorymysql-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/inventorymysql-0.4.0.tgz
     version: 0.4.0
   mysql:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.862021609-05:00
+    created: 2018-08-21T12:01:54.692841-05:00
     description: Resilient MySQL deployment
     digest: 3e906fc650fee7406ec0c8629968ceabe28af0e337cf8e403259b7983f529e24
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Octicons-database.svg/200px-Octicons-database.svg.png
     name: mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/mysql-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/mysql-0.2.0.tgz
     version: 0.2.0
   orders:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.863505904-05:00
+    created: 2018-08-21T12:01:54.695544-05:00
     description: Bluecompute Orders Microservice
     digest: 849b0acbae8bbac1ab944d1bac093610b39d536f252e76580db11cc94a028a4b
     name: orders
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/orders-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/orders-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.863273858-05:00
+    created: 2018-08-21T12:01:54.695287-05:00
     description: Bluecompute Orders Microservice
     digest: b2a14f301797334aeaad321d02fca1297dd0927bcd43b57e8cf06145e979c4b8
     name: orders
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/orders-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/orders-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.86303255-05:00
+    created: 2018-08-21T12:01:54.695039-05:00
     description: Bluecompute Orders Microservice
     digest: f7fe5f945a164da69c2d782f993fa95fd8f00d386a56c58369bb2fe6f7c3b637
     name: orders
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/orders-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/orders-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.862551107-05:00
+    created: 2018-08-21T12:01:54.69422-05:00
     description: Bluecompute Orders Microservice
     digest: e80032e4c5cd126bfe542f55fcf53994c1728a4b4b52336fa93198c20b02718b
     name: orders
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/orders-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/orders-0.1.0.tgz
     version: 0.1.0
   ordersmysql:
-  - created: 2018-07-27T16:57:04.863776623-05:00
+  - created: 2018-08-21T12:01:54.695827-05:00
     description: Fast, reliable, scalable, and easy to use open-source relational
       database system.
     digest: 61df30b8c6b0d3bbd22a53fd4ad66c83bdf75a41e6af5f7b5c4f7b4156938b2d
@@ -519,39 +519,39 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/docker-library/mysql
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/ordersmysql-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/ordersmysql-0.4.0.tgz
     version: 0.4.0
   web:
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.865478863-05:00
+    created: 2018-08-21T12:01:54.696895-05:00
     description: BlueCompute Web BFF app
     digest: 57b8eb6ae77c2f4ac171661b7fa779b3891973df7cce794ace7b745a22890892
     name: web
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/web-0.4.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/web-0.4.0.tgz
     version: 0.4.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.865165735-05:00
+    created: 2018-08-21T12:01:54.696616-05:00
     description: BlueCompute Web BFF app
     digest: 8b87fc0c2a7aa98eaaefe6ef97ea145c2a6cad903f8f0ed8e6c5c9a9cd9eb162
     name: web
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/web-0.3.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/web-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.864547123-05:00
+    created: 2018-08-21T12:01:54.696347-05:00
     description: BlueCompute Web BFF app
     digest: 31f11c627273cfe348904201001bdab124fad03a55552b17e3e79cb2213a99a9
     name: web
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/web-0.2.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/web-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
-    created: 2018-07-27T16:57:04.864038778-05:00
+    created: 2018-08-21T12:01:54.696084-05:00
     description: BlueCompute Web BFF app
     digest: 578c75f83599b095fb0bd9e95034930442198c1e830dd4eea50c8cf62a460b15
     name: web
     urls:
-    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/master/docs/charts/web-0.1.0.tgz
+    - https://raw.githubusercontent.com/ibm-cloud-architecture/refarch-cloudnative-kubernetes/spring/docs/charts/web-0.1.0.tgz
     version: 0.1.0
-generated: 2018-07-27T16:57:04.847924289-05:00
+generated: 2018-08-21T12:01:54.676037-05:00


### PR DESCRIPTION
With the updates to the branches, we need to also update the internalized URLs for the Helm Chart repositories (both `requirements.yaml` and `index.yaml`).  